### PR TITLE
Remove deprecared JUnit5TestShouldBePackagePrivate rule

### DIFF
--- a/buildtools/src/main/resources/cxf-pmd-ruleset.xml
+++ b/buildtools/src/main/resources/cxf-pmd-ruleset.xml
@@ -49,7 +49,6 @@
         <exclude name="ForLoopVariableCount" />
         <exclude name="GuardLogStatement" />
         <exclude name="JUnitUseExpected"/>
-        <exclude name="JUnit5TestShouldBePackagePrivate" />
         <exclude name="LooseCoupling" />
         <exclude name="MethodReturnsInternalArray" />
         <exclude name="MissingOverride" />


### PR DESCRIPTION
Remove deprecared JUnit5TestShouldBePackagePrivate rule: https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate